### PR TITLE
Fix compilation on older MSVC

### DIFF
--- a/src/cudf_types.h
+++ b/src/cudf_types.h
@@ -14,8 +14,10 @@
 typedef long long int CUDFcoefficient;  // type of coefficients
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 #define CUDFabs llabs                   // absolute value of a coefficient
+#define CUDFnearbyint nearbyint
 #else
 #define CUDFabs _abs64
+#define CUDFnearbyint(e) ((int)floor((e) + 0.5))
 #endif
 
 #ifdef _WIN32

--- a/src/cudf_types.h
+++ b/src/cudf_types.h
@@ -12,7 +12,11 @@
 
 
 typedef long long int CUDFcoefficient;  // type of coefficients
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 #define CUDFabs llabs                   // absolute value of a coefficient
+#else
+#define CUDFabs _abs64
+#endif
 
 #ifdef _WIN32
 // See note in cudf.h about __MINGW_USE_ANSI_STDIO. This check ensures that the

--- a/src/glpk_solver.cpp
+++ b/src/glpk_solver.cpp
@@ -152,13 +152,13 @@ int glpk_solver::solve() {
 }
 
 // get objective function value
-CUDFcoefficient glpk_solver::objective_value() { return (CUDFcoefficient)nearbyint(glp_mip_obj_val(lp)); }
+CUDFcoefficient glpk_solver::objective_value() { return (CUDFcoefficient)CUDFnearbyint(glp_mip_obj_val(lp)); }
 
 // solution initialisation
 int glpk_solver::init_solutions() { return 0; }
 
 // return the status of a package within the final configuration
-CUDFcoefficient glpk_solver::get_solution(CUDFVersionedPackage *package) { return (CUDFcoefficient)nearbyint(glp_mip_col_val(lp, package->rank+1)); }
+CUDFcoefficient glpk_solver::get_solution(CUDFVersionedPackage *package) { return (CUDFcoefficient)CUDFnearbyint(glp_mip_col_val(lp, package->rank+1)); }
 
 // initialize objective function
 int glpk_solver::begin_objectives(void) { 


### PR DESCRIPTION
One easy fix: `llabs` was called `_abs64` prior to Visual Studio 2015.

Visual Studio 2015 was also the point at which Microsoft finally added lots of missing functions, as they moved towards C99 support, which includes `nearbyint` (the mingw ports are fine, because mingw-w64 has a library libmingwex which has filled in the gaps for missing functions like this). I have gone on the basis that `fesetround` is not called anywhere in the code, so doing an old fashioned "add 0.5 and floor it" should do. But even that much floating point reading has brought me out in hives, so that might want checking...