### PR TITLE
Fix running macOS tests without GNU diffutils

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 # Default behaviour, for if core.autocrlf isn't set
 * text=auto
 
+.travis-ci.sh text eol=lf
+
 appveyor.sh text eol=lf
 appveyor/*.patch text eol=lf
 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -5,7 +5,6 @@ case $TRAVIS_OS_NAME in
     sudo apt-get install coinor-libclp-dev coinor-libcbc-dev coinor-libsymphony-dev mccs
     ;;
   osx)
-    brew install diffutils
     ;;
   *)
     echo "Unknown TRAVIS_OS_NAME: $TRAVIS_OS_NAME" >&2

--- a/test/gen_tests.ml
+++ b/test/gen_tests.ml
@@ -17,6 +17,14 @@ let test name ?solver ?ignore ?(ref="") () =
     | None -> ""
     | Some solver -> Printf.sprintf " \"%s\"" solver
   in
+  let ignore_eol =
+    (* This means that an LF check-out on Windows won't cause a problem with
+       CRLF output from the test program. Assume GNU diff present on Windows. *)
+    if Sys.win32 || Sys.cygwin then
+      "--ignore-trailing-space "
+    else
+      ""
+  in
   let () =
     match ignore with
     | None ->
@@ -41,7 +49,7 @@ let test name ?solver ?ignore ?(ref="") () =
 
 (alias
  ((name runtest)
-  (action (system \"diff --ignore-trailing-space ${path:test-%s.result} ${path:test.%s.reference}\"))))\n" name name
+  (action (system \"diff %s${path:test-%s.result} ${path:test.%s.reference}\"))))\n" ignore_eol name name
 
 let () =
   print_endline "; This file is generated using `MCCS_BACKENDS=jbuilder build @settests --auto-promote`";

--- a/test/jbuild.inc
+++ b/test/jbuild.inc
@@ -8,4 +8,4 @@
 
 (alias
  ((name runtest)
-  (action (system "diff --ignore-trailing-space ${path:test-glpk.result} ${path:test.glpk.reference}"))))
+  (action (system "diff ${path:test-glpk.result} ${path:test.glpk.reference}"))))


### PR DESCRIPTION
Addresses https://github.com/ocaml/opam-repository/pull/12078

(CI needs to run, obviously!)