### PR TITLE
fix warning on macos and bsd

### DIFF
--- a/src/glpk/env/env.h
+++ b/src/glpk/env/env.h
@@ -29,7 +29,10 @@
 typedef struct ENV ENV;
 typedef struct MBD MBD;
 
+#ifndef SIZE_T_MAX
 #define SIZE_T_MAX (~(size_t)0)
+#endif
+
 /* largest value of size_t type */
 
 #define TBUF_SIZE 4096


### PR DESCRIPTION
SIZE_T_MAX is defined in limits.h, so without this patch there
are many many warnings while building mccs on these systems.
