### PR TITLE
Modify CXXFLAGS to build on Darwin.

### DIFF
--- a/src/context_flags.ml
+++ b/src/context_flags.ml
@@ -24,6 +24,7 @@ let ifc c x = if c then x else []
 
 let cxxflags =
   let flags =
+    (ifc (Config.system = "macosx") ["-x"; "c++"]) @
     (ifc (Sys.win32 && Config.ccomp_type = "msvc") ["/EHsc"]) @
     (ifc useGLPK ["-DUSEGLPK"]) @
     (ifc useCOIN ["-DUSECOIN"]) @


### PR DESCRIPTION
Clang needs either `-x c++` or invocation as `clang++` to compile C++,
just invoking it on a .cpp/.cxx file is insufficient.

Fixes #12.