### PR TITLE
Fix #16: Remove RTTI for linking on Windows

### DIFF
--- a/src/context_flags.ml
+++ b/src/context_flags.ml
@@ -25,6 +25,7 @@ let ifc c x = if c then x else []
 let cxxflags =
   let flags =
     (ifc (Sys.win32 && Config.ccomp_type = "msvc") ["/EHsc"]) @
+    (ifc (Config.system = "mingw" || Config.system = "mingw64") ["-fno-rtti"]) @
     (ifc useGLPK ["-DUSEGLPK"]) @
     (ifc useCOIN ["-DUSECOIN"]) @
     (ifc useCLP  ["-DUSECLP"]) @


### PR DESCRIPTION
This is a proposal to fix #16 by passing the `-fno-rtti` flag in mingw/mingw64 environments.

I believe this should be safe, because the RTTI features don't appear to be used (there are exceptions, but they get their type info via a separate mechanism).

With this fix, along with linking the `libgcc_s.a` lib on Windows in esy-solve-cudf, we're able to build successfully.