### PR TITLE
Fix Gc weirdness on macOS

### DIFF
--- a/src/mccs_stubs.cpp
+++ b/src/mccs_stubs.cpp
@@ -161,14 +161,16 @@ CUDFVpkg * ml2c_vpkg(Virtual_packages * tbl, value ml_vpkg)
 value c2ml_vpkg(CUDFVpkg * vpkg)
 {
   CAMLparam0 ();
-  CAMLlocal2(ml_name, ml_cstr);
+  CAMLlocal4(ml_name, ml_cstr, ml_p, ml_s);
   ml_name = caml_copy_string(vpkg->virtual_package->name);
   if (vpkg->op == op_none)
-    CAMLreturn(Val_pair(ml_name, Val_none));
+    ml_p = Val_pair(ml_name, Val_none);
   else {
     ml_cstr = Val_pair(c2ml_relop(vpkg->op), Val_int(vpkg->version));
-    CAMLreturn(Val_pair(ml_name, Val_some(ml_cstr)));
+    ml_s = Val_some(ml_cstr);
+    ml_p = Val_pair(ml_name, ml_s);
   }
+  CAMLreturn(ml_p);
 }
 
 CUDFVpkgList * ml2c_vpkglist(Virtual_packages * tbl, value ml_vpkglist)


### PR DESCRIPTION
Due to the weird interaction with Gc and `Val_pair(.., Val_some(..))` the c2ml
conversion code were failing on macOS.

The bug was triggered only on macOS and only some CUDF input document, the stacktrace looks like this:

```
Invalid_argument("String.blit / Bytes.blit_string")
  Raised at file "pervasives.ml", line 33, characters 20-45
  Called from file "buffer.ml" (inlined), line 176, characters 2-47
  Called from file "camlinternalFormat.ml", line 1913, characters 48-69
  Called from file "camlinternalFormat.ml", line 1915, characters 32-46
  Called from file "camlinternalFormat.ml", line 1913, characters 32-46
  Called from file "camlinternalFormat.ml", line 1915, characters 32-46
  Called from file "camlinternalFormat.ml", line 1913, characters 32-46
  Called from file "printf.ml", line 35, characters 4-22
  Called from file "cudf_types_pp.ml", line 143, characters 40-61
  Called from file "cudf_types_pp.ml", line 137, characters 30-51
  Called from file "cudf_types_pp.ml", line 144, characters 13-18
  Called from file "cudf_printer.ml", line 32, characters 19-52
  Called from file "cudf_printer.ml", line 71, characters 28-46
  Called from file "hashtbl.ml", line 266, characters 8-18
  Called from file "hashtbl.ml", line 272, characters 6-21
  Re-raised at file "hashtbl.ml", line 277, characters 4-13
  Called from file "cudf_printer.ml" (inlined), line 131, characters 2-101
  Called from file "bin/esySolveCudfCommand.ml", line 36, characters 25-65
  Called from file "src/cmdliner_term.ml", line 27, characters 19-24
  Called from file "src/cmdliner.ml", line 27, characters 27-34
  Called from file "src/cmdliner.ml", line 106, characters 32-39
```

Ref https://github.com/esy/esy/issues/329