### PR TITLE
Avoid vendored glpk.h for external builds

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -20,14 +20,18 @@
  (libraries
   cudf
   (select
-   _
+   config.h
    from
-   (mccs.glpk.internal -> _)
-   (mccs.glpk.shared -> _)
-   (mccs.glpk.static -> _)
+   (mccs.glpk.internal -> config_internal.h)
+   (mccs.glpk.shared -> config_external.h)
+   (mccs.glpk.static -> config_external.h)
    (-> _))))
 
-(copy_files# glpk/glpk.h)
+(rule
+  (with-stdout-to config_internal.h (echo "#include \"glpk/glpk.h\"")))
+
+(rule
+  (with-stdout-to config_external.h (echo "#include <glpk.h>")))
 
 (rule
  (targets cxxflags.sexp clibs.sexp flags.sexp)

--- a/src/glpk_solver.h
+++ b/src/glpk_solver.h
@@ -12,7 +12,7 @@
 
 #include <abstract_solver.h>
 #include <scoeff_solver.h>
-#include <glpk.h>
+#include "config.h"
 
 class glpk_solver: public abstract_solver, public scoeff_solver<double, 1, 1>  {
  public:


### PR DESCRIPTION
If you enable the shared library build, Dune is still instructed to copy the vendored `glpk.h` into `_build`, which is not correct.