### PR TITLE
Don't redefine macros with OCaml 4.12

### DIFF
--- a/src/mccs_stubs.cpp
+++ b/src/mccs_stubs.cpp
@@ -23,8 +23,10 @@
 #include <osi_solver.h>
 #endif
 
+#if OCAML_VERSION < 41200
 #define Val_none Val_int(0)
-#define Some_val(v)  Field(v,0)
+#define Some_val(v) Field(v, 0)
+#endif
 
 value Val_some (value v)
 {


### PR DESCRIPTION
Macros `Val_none` and `Some_val` are part of the standard library
starting with OCaml 4.12.

In some environments, redefining a macro triggers a compiler warning.
When warnings are treated as errors, the build fails.

Issue discussing the introduction of the macros, the problem, and the
fix: https://github.com/ocaml/ocaml/issues/5154

Commit introducing the macros in the standard library:
https://github.com/ocaml/ocaml/commit/973eeb1867f41ef2669ad4cbfa9c2e76ddef1749