### PR TITLE
Always include std headers first

### DIFF
--- a/src/lp_solver.cpp
+++ b/src/lp_solver.cpp
@@ -5,7 +5,6 @@
 /*******************************************************/
 
 
-#include <lp_solver.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -14,6 +13,8 @@
 #else
 #include <unistd.h>
 #endif
+
+#include <lp_solver.h>
 
 #define CLEAN_FILES 1
 #ifdef _WIN32


### PR DESCRIPTION
C++17 added std::byte which can cause issues with headers on Windows which also have a byte typedef if that header is included after a using namespace std; statement.

Fixes build with g++ 11 on mingw-w64.