### PR TITLE
Add `-lgcc_s` on Cygwin

### DIFF
--- a/src/context_flags.ml
+++ b/src/context_flags.ml
@@ -37,6 +37,7 @@ let cxxflags =
 let clibs =
   let flags =
     (ifc (Config.ccomp_type = "cc") ["-lstdc++"]) @
+    (ifc (Config.system = "cygwin") ["-lgcc_s"]) @
     (ifc useCOIN ["-lCoinUtils"]) @
     (ifc useCLP  ["-lOsiClp"]) @
     (ifc useCBC  ["-lOsiCbc";"-lCbc"]) @


### PR DESCRIPTION
Cygwin's packaged `flexlink` adds this by default, but vanilla `flexlink` does not.