### PR TITLE
Allow to set the verbosity level in GLPK

### DIFF
--- a/src/mccs.ml
+++ b/src/mccs.ml
@@ -75,13 +75,13 @@ let problem_of_cudf cudf =
   pb
 
 let resolve_cudf
-    ?(verbose=false) ?timeout ?(solver=default_solver)
+    ?(verbosity=0) ?timeout ?(solver=default_solver)
     criteria (preamble, _, _ as cudf) =
   let timeout = match timeout with
     | None -> 0
     | Some f -> int_of_float (1000. *. f)
   in
-  set_verbosity (if verbose then 1 else 0);
+  set_verbosity (max 0 verbosity);
   let pb = problem_of_cudf cudf in
   match call_solver solver criteria timeout pb with
   | None -> None

--- a/src/mccs.mli
+++ b/src/mccs.mli
@@ -19,7 +19,7 @@ type solver_backend = [ `GLPK | `LP of string | `COIN_CLP | `COIN_CBC | `COIN_SY
 (** Resolve the given problem. The timeout is in seconds, default is to never
     time out. *)
 val resolve_cudf:
-  ?verbose:bool -> ?timeout:float -> ?solver:solver_backend ->
+  ?verbosity:int -> ?timeout:float -> ?solver:solver_backend ->
   string -> Cudf.cudf -> Cudf.solution option
 
 (** Deprecated, corresponds to the default solver backend selection only *)


### PR DESCRIPTION
`verbosity` is set to either 1 or 0 so `msg_lev` was never equal to `GLP_MSG_ON`. This change allows to set it a variable level and change the quantity of output depending on the verbosity level.