### PR TITLE
Fixes verbosity flags not being respected in GLPK 

### DIFF
--- a/mccs.opam
+++ b/mccs.opam
@@ -11,8 +11,6 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-clause" "GPL-
 dev-repo: "git+https://github.com/ocaml-opam/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"

--- a/mccs.opam
+++ b/mccs.opam
@@ -11,6 +11,8 @@ license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception" "BSD-3-clause" "GPL-
 dev-repo: "git+https://github.com/ocaml-opam/ocaml-mccs.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
+  ["sh" "-c" "dune build @settests --auto-promote || true"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"

--- a/src/glpk/api/cpxbas.c
+++ b/src/glpk/api/cpxbas.c
@@ -256,11 +256,14 @@ static void cpx_basis(glp_prob *lp)
 *  Robert E. Bixby. Implementing the Simplex Method: The Initial Basis.
 *  ORSA Journal on Computing, Vol. 4, No. 3, 1992, pp. 267-84. */
 
-void glp_cpx_basis(glp_prob *lp)
+void glp_cpx_basis(glp_prob *lp, int verbosity)
 {     if (lp->m == 0 || lp->n == 0)
          glp_std_basis(lp);
-      else
-         cpx_basis(lp);
+      else {
+        ENV *env = get_env_ptr();
+        env->term_out = verbosity;
+        cpx_basis(lp);
+      }
       return;
 }
 

--- a/src/glpk/draft/glpios03.c
+++ b/src/glpk/draft/glpios03.c
@@ -1018,7 +1018,14 @@ loop: /* main loop starts here */
                xprintf("Cover cuts enabled\n");
 #ifdef NEW_COVER /* 13/II-2018 */
             xassert(T->cov_gen == NULL);
-            T->cov_gen = glp_cov_init(T->mip);
+         ENV *env = get_env_ptr();
+         int term_out = env->term_out;
+         if (!term_out || T->parm->msg_lev < GLP_MSG_ALL)
+            env->term_out = GLP_OFF;
+         else
+            env->term_out = GLP_ON;
+	 T->cov_gen = glp_cov_init(T->mip);
+         env->term_out = term_out;
 #endif
          }
          if (T->parm->clq_cuts == GLP_ON)
@@ -1028,6 +1035,8 @@ loop: /* main loop starts here */
 #if 0 /* 08/III-2016 */
             T->clq_gen = ios_clq_init(T);
 #else
+	    ENV *env = get_env_ptr();
+	    env->term_out = T->parm->msg_lev;
             T->clq_gen = glp_cfg_init(T->mip);
 #endif
          }

--- a/src/glpk/glpk.h
+++ b/src/glpk/glpk.h
@@ -463,7 +463,7 @@ void glp_std_basis(glp_prob *P);
 void glp_adv_basis(glp_prob *P, int flags);
 /* construct advanced initial LP basis */
 
-void glp_cpx_basis(glp_prob *P);
+void glp_cpx_basis(glp_prob *P, int verbosity);
 /* construct Bixby's initial LP basis */
 
 int glp_simplex(glp_prob *P, const glp_smcp *parm);

--- a/src/glpk_solver.cpp
+++ b/src/glpk_solver.cpp
@@ -96,7 +96,7 @@ int glpk_solver::solve(int timeout) {
   this->aborted = false;
 
   for (int k = 0; k < nb_objectives; k++) {
-    glp_cpx_basis(lp);
+    glp_cpx_basis(lp, verbosity);
   
     if (status == 0) status = glp_intopt(lp, &this->mip_params);
 


### PR DESCRIPTION
Recently I noticed logs from GLPK backend on MacOS  Azure Pipelines runner. This PR adds verbosity flag checks so that the verbosity level is respected everywhere.

TBH, I'm not so sure why this wasn't discovered earlier. Something to do with Apple/Clang?