### PR TITLE
Fix debug logs showing up regardless of verbosity on macOS 12.7.1 / 13.6.3 / 14.2

### DIFF
--- a/src/glpk_solver.cpp
+++ b/src/glpk_solver.cpp
@@ -79,7 +79,7 @@ int glpk_solver::solve(int timeout) {
   try {
   if (verbosity == 0) {
     save_stdout = dup(1);
-    close(1);
+    fclose(stdout); /* close(1) does not close stdout on macOS since macOS 12.7.1 / 13.6.3 / 14.2 (the bug has been reported) */
   }
   glp_init_iocp(&this->mip_params);
   this->mip_params.gmi_cuts = GLP_ON;

--- a/src/osi_solver.h
+++ b/src/osi_solver.h
@@ -242,7 +242,7 @@ int osi_solver<OsiSolver>::solve(int timeout) {
   try {
   if (verbosity == 0) {
     save_stdout = dup(1);
-    close(1);
+    fclose(stdout); /* close(1) does not close stdout on macOS since macOS 12.7.1 / 13.6.3 / 14.2 (the bug has been reported) */
   }
 
   double * obj_v = objectives[0].denseVector(nb_vars);


### PR DESCRIPTION
Fixes https://github.com/ocaml-opam/ocaml-mccs/issues/48

This seems to be a bug in macOS 12.7.1 / 13.6.3 / 14.2, this has been reported to Apple.
This was tested successfully on Linux and macOS, i haven’t tried BSDs or Windows yet.